### PR TITLE
feat: initial release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,25 @@
-# metaplex-dotstorage-auth
+# metaplex-auth
 
 This repo contains a client library for uploading data to [NFT.Storage](https://nft.storage) using a signature from a solana private key to authenticate the request.
 
 See [SPEC.md](./SPEC.md) for details about the authentication scheme.
 
+## Install
+
+```
+npm install @nftstorage/metaplex-auth
+```
+
+or
+
+```
+yarn add @nftstorage/metaplex-auth
+```
+
 ## Usage
 
 ```js
-import { MetaplexAuthWithSecretKey, NFTStorageUploader } from 'metaplex-dotstorage-auth'
+import { MetaplexAuthWithSecretKey, NFTStorageUploader } from '@nftstorage/metaplex-auth'
 import { getFilesFromPath } from 'files-from-path'
 
 async function upload(filenames) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "metaplex-dotstorage-auth",
-  "version": "1.0.0",
+  "name": "metaplex-auth",
+  "version": "0.1.0",
   "description": "A client library for nft.storage designed for metaplex NFT uploads",
   "main": "./dist/index.cjs",
   "files": [

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -55,8 +55,7 @@ abstract class Uploader {
   /**
    * Uploads a Blob containing data of type `application/car` to this Uploader's API.
    * 
-   * Must be defined in derived classes. See {@link NFTStorageUploader.putCarFile} and
-   * {@link Web3StorageUploader.putCarFile}.
+   * Must be defined in derived classes. See {@link NFTStorageUploader.putCarFile}.
    * 
    * @param carFile - a Blob containing CAR data, with content type set to `application/car`.
    * @param carRoot - the root CID of the CAR file, as a string.
@@ -156,34 +155,3 @@ export class NFTStorageUploader extends Uploader {
     return carRoot
   }
 }
-
-
-export class Web3StorageUploader extends Uploader {
-  endpoint: string
-
-  constructor(auth: AuthContext, endpoint: string = "https://api.web3.storage") {
-    super(auth)
-    this.endpoint = endpoint
-  }
-
-  async putCarFile (carFile: Blob, carRoot: string, uploadCreds: UploadCredentials): Promise<string> {
-    const putCarEndpoint = new URL("/car", this.endpoint)
-
-    const headers = metaplexAuthHeaders(uploadCreds)
-    const request = await fetch(putCarEndpoint.toString(), {
-      method: 'POST',
-      headers,
-      body: carFile
-    })
-    const res = await request.json() as { message?: string, cid?: string }
-    if (!request.ok) {
-      throw new Error(res.message)
-    }
-
-    if (res.cid !== carRoot) {
-      throw new Error(`root CID mismatch, expected: ${carRoot}, received: ${res.cid}`)
-    }
-    return carRoot
-  }
-}
-


### PR DESCRIPTION
Cleaning up and squaring things away before publishing to npm.

So far:

- changes package name to `metaplex-auth`
- updates readme to import from `@nftstorage/metaplex-auth`
- removes the unused `Web3StorageUploader` (from an early draft, not supported by the web3.storage backend)


