### PR TITLE
chore: fix browser build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:all": "npm run build:esm && npm run build:cjs && npm run build:browser",
     "build:cjs": "mkdirp ./dist && esbuild ./src/index.ts --bundle --format=cjs --platform=node --inject:./src/platform.node.js --target=es2018 --outfile=./dist/index.cjs",
     "build:esm": "mkdirp ./dist && esbuild ./src/index.ts --bundle --format=esm --platform=node --inject:./src/platform.node.js --target=es2018 --outfile=./dist/index.esm.js",
-    "build:browser": "mkdirp ./dist && esbuild ./src/index.ts --bundle --format=esm --target=es2018 --outfile=./dist/index.browser.js",
+    "build:browser": "mkdirp ./dist && esbuild ./src/index.ts --bundle --format=esm --target=es2018 --external:fs --external:path --outfile=./dist/index.browser.js",
     "build:cli": "mkdirp ./dist && esbuild ./src/cli.ts --bundle --format=cjs --platform=node --inject:./src/platform.node.js --target=es2018 --outfile=./dist/cli.js",
     "prepublishOnly": "npm run test && npm run build",
     "test": "node test/utils/test.mjs mocha",


### PR DESCRIPTION
We only import `path` and `fs` at runtime after we make sure we're not running a browser, but esbuild needs to be told that they're external and not to bundle them for the browser build.