### PR TITLE
feat: include metadata in StoreNFTResult

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nftstorage/metaplex-auth",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A client library for nft.storage designed for metaplex NFT uploads",
   "main": "./dist/index.cjs",
   "files": [

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -37,6 +37,9 @@ export interface StoreNFTResult {
 
   /** ipfs:// URI for metadata json file */
   metadataURI: string
+
+  /** The metadata that was stored with NFT.Storage, as a JS object */
+  metadata: Record<string, any>
 }
 
 /**
@@ -191,6 +194,7 @@ export class NFTStorageMetaplexor {
       assetRootCID,
       metadataGatewayURL,
       metadataURI,
+      metadata: nft.metadata,
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,11 @@ export const isBrowser =
   typeof window !== 'undefined' && typeof window.document !== 'undefined'
 
 export function makeGatewayURL(cid: string, path: string): string {
-  const base = new URL(`/ipfs/${cid}`, GATEWAY_HOST)
+  let pathPrefix = `/ipfs/${cid}`
+  if (path) {
+    pathPrefix += '/'
+  }
+  const base = new URL(pathPrefix, GATEWAY_HOST)
   const u = new URL(path, base)
   return u.toString()
 }

--- a/test/nft.spec.ts
+++ b/test/nft.spec.ts
@@ -14,8 +14,9 @@ describe('loadNFTFromFilesystem', () => {
     )
     const nft = await loadNFTFromFilesystem(jsonPath)
     const expectedURI =
-      'ipfs://bafybeiarsqflqrvw23zegn73yr4fgs6vccnlpu545p5trcevrf46kvkkdy/metadata.json'
+      'ipfs://bafybeiegbfxiiz26tqzrcl4xyhf42vxrseeouubiwhmmlgrb4t2rbdiruu/metadata.json'
     expect(nft.metadataURI).to.equal(expectedURI)
+    console.log(nft.metadata)
   })
 
   it('finds image file if json "image" field contains valid file path', async () => {
@@ -28,7 +29,7 @@ describe('loadNFTFromFilesystem', () => {
     )
     const nft = await loadNFTFromFilesystem(jsonPath)
     const expectedURI =
-      'ipfs://bafybeiarsqflqrvw23zegn73yr4fgs6vccnlpu545p5trcevrf46kvkkdy/metadata.json'
+      'ipfs://bafybeiegbfxiiz26tqzrcl4xyhf42vxrseeouubiwhmmlgrb4t2rbdiruu/metadata.json'
     expect(nft.metadataURI).to.equal(expectedURI)
   })
 
@@ -49,7 +50,7 @@ describe('loadNFTFromFilesystem', () => {
     )
     const nft = await loadNFTFromFilesystem(jsonPath, imagePath)
     const expectedURI =
-      'ipfs://bafybeiarsqflqrvw23zegn73yr4fgs6vccnlpu545p5trcevrf46kvkkdy/metadata.json'
+      'ipfs://bafybeiegbfxiiz26tqzrcl4xyhf42vxrseeouubiwhmmlgrb4t2rbdiruu/metadata.json'
     expect(nft.metadataURI).to.equal(expectedURI)
   })
 })

--- a/test/upload.spec.ts
+++ b/test/upload.spec.ts
@@ -86,6 +86,9 @@ describe('NFTStorageMetaplexor', () => {
       const result = await client.storeNFTFromFilesystem(metadataPath)
       expect(result.assetRootCID).to.not.be.empty
       expect(result.metadataRootCID).to.not.be.empty
+      expect(result.metadata['image']).to.eq(
+        `https://dweb.link/ipfs/${result.assetRootCID}/token.png`
+      )
     })
   })
 })


### PR DESCRIPTION
This includes the final metadata (with rewritten links) in the `StoreNFTResult` object, to make it easier to access.

Also fixes a bug in `toGatewayURL` that was causing incorrect paths.