### PR TITLE
fix: use private keyword instead of # for pre-ES2015 compat

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -51,7 +51,7 @@ export interface StoreNFTResult {
  *
  */
 export class NFTStorageMetaplexor {
-  static #initialized: boolean
+  private static _initialized: boolean
   auth: AuthContext
   endpoint: URL
 
@@ -59,14 +59,14 @@ export class NFTStorageMetaplexor {
   // an 'x-web3auth' header instead of 'Authorization'.
   // Must be called before calling NFTStorage.storeCar
   static #init() {
-    if (this.#initialized) {
+    if (this._initialized) {
       return
     }
     // @ts-ignore
     NFTStorage.auth = (token: string) => ({
       'x-web3auth': `Metaplex ${token}`,
     })
-    this.#initialized = true
+    this._initialized = true
   }
 
   constructor({ auth, endpoint }: ServiceContext) {


### PR DESCRIPTION
Apparently including this lib in a project that targets an ES standard prior to ES2015 fails:

```
$ tsc -p ./src
../../node_modules/@nftstorage/metaplex-auth/dist/src/upload.d.ts(39,5): error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
```

So this commit changes `#initialized` to `_initialized` and marks it with TypeScript's `private` keyword instead.