### PR TITLE
feat: pack nfts into single car file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nftstorage/metaplex-auth",
-  "version": "0.1.0",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nftstorage/metaplex-auth",
-      "version": "0.1.0",
+      "version": "0.2.3",
       "license": "ISC",
       "dependencies": {
         "@solana/web3.js": "^1.30.2",
@@ -14,6 +14,7 @@
         "@web-std/file": "^1.1.4",
         "ajv": "^8.8.1",
         "files-from-path": "^0.2.1",
+        "ipfs-car": "^0.6.0",
         "multiformats": "^9.4.10",
         "nft.storage": "^4.0.0",
         "p-retry": "^5.0.0",
@@ -522,6 +523,22 @@
         "web-streams-polyfill": "3.0.3"
       }
     },
+    "node_modules/@web-std/stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.0.tgz",
+      "integrity": "sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==",
+      "dependencies": {
+        "web-streams-polyfill": "^3.1.1"
+      }
+    },
+    "node_modules/@web-std/stream/node_modules/web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@web3-storage/multipart-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
@@ -809,6 +826,34 @@
       "dependencies": {
         "browser-readablestream-to-it": "^1.0.3"
       }
+    },
+    "node_modules/blockstore-core": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-1.0.2.tgz",
+      "integrity": "sha512-CYOaAvgVoJDqxbGG4YVyLMZ5mmS+Icwn7oHnayPko/FGpiinixI/CGMrErbDSaVSkjhuea9tpU23tt+Jx13n+g==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "interface-blockstore": "^2.0.2",
+        "interface-store": "^2.0.1",
+        "it-drain": "^1.0.4",
+        "it-filter": "^1.0.2",
+        "it-take": "^1.0.1",
+        "multiformats": "^9.4.7"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/interface-blockstore": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.2.tgz",
+      "integrity": "sha512-2OonKanTF7xnlqe879EgYwv94e7jYO20dDMyqkDum7b9RnhdMkiLAOkeStlvxX1sZBLjcThyHzFTUYTK4ohKpg==",
+      "dependencies": {
+        "interface-store": "^2.0.1",
+        "multiformats": "^9.0.4"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/interface-store": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.1.tgz",
+      "integrity": "sha512-TfjYMdk4RlaGPA0VGk8fVPM+xhFbjiA2mTv1AqhiFh3N+ZEwoJnmDu/EBdKXzl80nyd0pvKui3RTC3zFgHMjTA=="
     },
     "node_modules/bn.js": {
       "version": "5.2.0",
@@ -1975,11 +2020,11 @@
       }
     },
     "node_modules/idb-keyval": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.5.tgz",
-      "integrity": "sha512-J1utxYWQokYjy01LvDQ7WmiAtZCGUSkVi9EIBfUSyLOr/BesnMIxNGASTh9A1LzeISSjSqEPsfFdTss7EE7ofQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.0.3.tgz",
+      "integrity": "sha512-yh8V7CnE6EQMu9YDwQXhRxwZh4nv+8xm/HV4ZqK4IiYFJBWYGjJuykADJbSP+F/GDXUBwCSSNn/14IpGL81TuA==",
       "dependencies": {
-        "safari-14-idb-fix": "^1.0.6"
+        "safari-14-idb-fix": "^3.0.0"
       }
     },
     "node_modules/ieee754": {
@@ -2055,20 +2100,19 @@
       }
     },
     "node_modules/interface-datastore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-5.2.0.tgz",
-      "integrity": "sha512-nthO4C4BMJM2j9x/mT2KFa/g/sbcY8yf9j/kOBgli3u5mq9ZdPvQyDxi0OhKzr4JmoM81OYh5xcFjyebquqwvA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.0.3.tgz",
+      "integrity": "sha512-61eOyzh7zH1ks/56hPudW6pbqsOdoHSYMVjuqlIlZGjyg0svR6DHlCcaeSJfWW8t6dsPl1n7qKBdk8ZqPzXuLA==",
       "dependencies": {
-        "err-code": "^3.0.1",
-        "interface-store": "^1.0.2",
-        "ipfs-utils": "^8.1.2",
-        "it-all": "^1.0.2",
-        "it-drain": "^1.0.1",
-        "it-filter": "^1.0.2",
-        "it-take": "^1.0.1",
+        "interface-store": "^2.0.1",
         "nanoid": "^3.0.2",
         "uint8arrays": "^3.0.0"
       }
+    },
+    "node_modules/interface-datastore/node_modules/interface-store": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.1.tgz",
+      "integrity": "sha512-TfjYMdk4RlaGPA0VGk8fVPM+xhFbjiA2mTv1AqhiFh3N+ZEwoJnmDu/EBdKXzl80nyd0pvKui3RTC3zFgHMjTA=="
     },
     "node_modules/interface-store": {
       "version": "1.0.2",
@@ -2097,21 +2141,22 @@
       }
     },
     "node_modules/ipfs-car": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.9.tgz",
-      "integrity": "sha512-81jKWdkFj1XjP23Qu2ts5K4VOZsLySD4V4UH8fQeb1T6ETf5btdm24mhRRuY7hvM/Vq7AMtDc+bDXocO+WouJQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.6.0.tgz",
+      "integrity": "sha512-2qw6u0Or/5cVKUR4bBCF/fzXnePSSIyF7m1hNUfg6kOBR7LJOXq6hhlCgu+2zGWVye9idsW8jEoPM9wYJp67jA==",
       "dependencies": {
         "@ipld/car": "^3.1.4",
-        "@web-std/blob": "^2.1.1",
+        "@web-std/blob": "^3.0.1",
         "bl": "^5.0.0",
+        "blockstore-core": "^1.0.2",
         "browser-readablestream-to-it": "^1.0.2",
-        "idb-keyval": "^5.0.6",
-        "interface-blockstore": "^1.0.0",
-        "ipfs-core-types": "^0.7.0",
-        "ipfs-core-utils": "^0.10.1",
+        "idb-keyval": "^6.0.3",
+        "interface-blockstore": "^2.0.2",
+        "ipfs-core-types": "^0.8.3",
+        "ipfs-core-utils": "^0.12.1",
         "ipfs-unixfs-exporter": "^7.0.4",
         "ipfs-unixfs-importer": "^9.0.4",
-        "ipfs-utils": "^8.1.5",
+        "ipfs-utils": "^9.0.2",
         "it-all": "^1.0.5",
         "it-last": "^1.0.5",
         "it-pipe": "^1.1.0",
@@ -2127,34 +2172,61 @@
         "ipfs-car": "dist/cjs/cli/cli.js"
       }
     },
-    "node_modules/ipfs-core-types": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.7.3.tgz",
-      "integrity": "sha512-FkmOlqhEf3yG0K8Qt7We7kqA0xKjj8pe0dmNK593I3cgMP0MQS/xjMj1CXVdGeZc5Nn5CJ+TsuQydPbJ+7Y8eQ==",
+    "node_modules/ipfs-car/node_modules/@web-std/blob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.1.tgz",
+      "integrity": "sha512-opuhO8ZGGUj2jdFwfgMjWjVdKaHlQanGWXxj5wV2YQ1uGTuL/SADnsDitpMfRb+lSpmQyzpwZFfj4CNKQuwSKQ==",
       "dependencies": {
-        "interface-datastore": "^5.2.0",
+        "@web-std/stream": "1.0.0",
+        "web-encoding": "1.1.5"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/interface-blockstore": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.2.tgz",
+      "integrity": "sha512-2OonKanTF7xnlqe879EgYwv94e7jYO20dDMyqkDum7b9RnhdMkiLAOkeStlvxX1sZBLjcThyHzFTUYTK4ohKpg==",
+      "dependencies": {
+        "interface-store": "^2.0.1",
+        "multiformats": "^9.0.4"
+      }
+    },
+    "node_modules/ipfs-car/node_modules/interface-store": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.1.tgz",
+      "integrity": "sha512-TfjYMdk4RlaGPA0VGk8fVPM+xhFbjiA2mTv1AqhiFh3N+ZEwoJnmDu/EBdKXzl80nyd0pvKui3RTC3zFgHMjTA=="
+    },
+    "node_modules/ipfs-core-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.8.4.tgz",
+      "integrity": "sha512-sbRZA1QX3xJ6ywTiVQZMOxhlhp4osAZX2SXx3azOLxAtxmGWDMkHYt722VV4nZ2GyJy8qyk5GHQIZ0uvQnpaTg==",
+      "dependencies": {
+        "interface-datastore": "^6.0.2",
         "multiaddr": "^10.0.0",
-        "multiformats": "^9.4.1"
+        "multiformats": "^9.4.13"
       }
     },
     "node_modules/ipfs-core-utils": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.10.5.tgz",
-      "integrity": "sha512-WPRbMkbn/99pKMF3h8x1/c19+eTXVWOZu1+cmlc3NLR6gMlCd8KNpcq9OCAvs9G1JHx3w/FbEWHnqJm0TJMvrw==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.12.2.tgz",
+      "integrity": "sha512-RfxP3rPhXuqKIUmTAUhmee6fmaV3A7LMnjOUikRKpSyqESz/DR7aGK7tbttMxkZdkSEr0rFXlqbyb0vVwmn0wQ==",
       "dependencies": {
         "any-signal": "^2.1.2",
         "blob-to-it": "^1.0.1",
         "browser-readablestream-to-it": "^1.0.1",
+        "debug": "^4.1.1",
         "err-code": "^3.0.1",
-        "ipfs-core-types": "^0.7.3",
+        "ipfs-core-types": "^0.8.4",
         "ipfs-unixfs": "^6.0.3",
-        "ipfs-utils": "^8.1.4",
+        "ipfs-utils": "^9.0.2",
         "it-all": "^1.0.4",
         "it-map": "^1.0.4",
         "it-peekable": "^1.0.2",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
         "multiaddr": "^10.0.0",
         "multiaddr-to-uri": "^8.0.0",
-        "multiformats": "^9.4.1",
+        "multiformats": "^9.4.13",
+        "nanoid": "^3.1.23",
         "parse-duration": "^1.0.0",
         "timeout-abort-controller": "^1.1.1",
         "uint8arrays": "^3.0.0"
@@ -2221,9 +2293,9 @@
       }
     },
     "node_modules/ipfs-utils": {
-      "version": "8.1.6",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.6.tgz",
-      "integrity": "sha512-V/cwb6113DrDhrjDTWImA6+zmJbpdbUkxdxmEQO7it8ykV76bBmzU1ZXSM0QR0qxGy9VW8dkUlPAC2K10VgSmw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.2.tgz",
+      "integrity": "sha512-o0DjVfd1kcr09fAYMkSnZ56ZkfoAzZhFWkizG3/tL7svukZpqyGyRxNlF58F+hsrn/oL8ouAP9x+4Hdf8XM+hg==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "any-signal": "^2.1.0",
@@ -2232,7 +2304,7 @@
         "err-code": "^3.0.1",
         "is-electron": "^2.2.0",
         "iso-url": "^1.1.5",
-        "it-glob": "~0.0.11",
+        "it-glob": "^1.0.1",
         "it-to-stream": "^1.0.0",
         "merge-options": "^3.0.4",
         "nanoid": "^3.1.20",
@@ -2348,9 +2420,9 @@
       }
     },
     "node_modules/is-electron": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
-      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
+      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2601,9 +2673,9 @@
       "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
     },
     "node_modules/it-glob": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.14.tgz",
-      "integrity": "sha512-TKKzs9CglbsihSpcwJPXN5DBUssu4akRzPlp8QJRCoLrKoaOpyY2V1qDlxx+UMivn0i114YyTd4AawWl7eqIdw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
       "dependencies": {
         "@types/minimatch": "^3.0.4",
         "minimatch": "^3.0.4"
@@ -3539,9 +3611,9 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "9.4.10",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.10.tgz",
-      "integrity": "sha512-BwWGvgqB/5J/cnWaOA0sXzJ+UGl+kyFAw3Sw1L6TN4oad34C9OpW+GCpYTYPDp4pUaXDC1EjvB3yv9Iodo1EhA=="
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.5.4.tgz",
+      "integrity": "sha512-MFT8e8BOLX7OZKfSBGm13FwYvJVI6MEcZ7hujUCpyJwvYyrC1anul50A0Ee74GdeJ77aYTO6YU1vO+oF8NqSIw=="
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -3595,6 +3667,136 @@
         "streaming-iterables": "^6.0.0"
       }
     },
+    "node_modules/nft.storage/node_modules/idb-keyval": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.5.tgz",
+      "integrity": "sha512-J1utxYWQokYjy01LvDQ7WmiAtZCGUSkVi9EIBfUSyLOr/BesnMIxNGASTh9A1LzeISSjSqEPsfFdTss7EE7ofQ==",
+      "dependencies": {
+        "safari-14-idb-fix": "^1.0.6"
+      }
+    },
+    "node_modules/nft.storage/node_modules/interface-datastore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-5.2.0.tgz",
+      "integrity": "sha512-nthO4C4BMJM2j9x/mT2KFa/g/sbcY8yf9j/kOBgli3u5mq9ZdPvQyDxi0OhKzr4JmoM81OYh5xcFjyebquqwvA==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "interface-store": "^1.0.2",
+        "ipfs-utils": "^8.1.2",
+        "it-all": "^1.0.2",
+        "it-drain": "^1.0.1",
+        "it-filter": "^1.0.2",
+        "it-take": "^1.0.1",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/nft.storage/node_modules/ipfs-car": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.10.tgz",
+      "integrity": "sha512-+ItXLbKNH6S4JvNTl7sOtdecLsIVV/kenyUTWYbIMdwwTzoJwbkv+8qdTyA90E2R2xkZ3cXvNlpreujvLCP5Ng==",
+      "dependencies": {
+        "@ipld/car": "^3.1.4",
+        "@web-std/blob": "^2.1.1",
+        "bl": "^5.0.0",
+        "browser-readablestream-to-it": "^1.0.2",
+        "idb-keyval": "^5.0.6",
+        "interface-blockstore": "^1.0.0",
+        "ipfs-core-types": "^0.7.0",
+        "ipfs-core-utils": "^0.10.1",
+        "ipfs-unixfs-exporter": "^7.0.4",
+        "ipfs-unixfs-importer": "^9.0.4",
+        "ipfs-utils": "^8.1.5",
+        "it-all": "^1.0.5",
+        "it-last": "^1.0.5",
+        "it-pipe": "^1.1.0",
+        "meow": "^9.0.0",
+        "move-file": "^2.1.0",
+        "multiformats": "^9.3.0",
+        "stream-to-it": "^0.2.3",
+        "streaming-iterables": "^6.0.0",
+        "uint8arrays": "^3.0.0"
+      },
+      "bin": {
+        "🚘": "dist/cjs/cli/cli.js",
+        "ipfs-car": "dist/cjs/cli/cli.js"
+      }
+    },
+    "node_modules/nft.storage/node_modules/ipfs-core-types": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.7.3.tgz",
+      "integrity": "sha512-FkmOlqhEf3yG0K8Qt7We7kqA0xKjj8pe0dmNK593I3cgMP0MQS/xjMj1CXVdGeZc5Nn5CJ+TsuQydPbJ+7Y8eQ==",
+      "dependencies": {
+        "interface-datastore": "^5.2.0",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.4.1"
+      }
+    },
+    "node_modules/nft.storage/node_modules/ipfs-core-utils": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.10.5.tgz",
+      "integrity": "sha512-WPRbMkbn/99pKMF3h8x1/c19+eTXVWOZu1+cmlc3NLR6gMlCd8KNpcq9OCAvs9G1JHx3w/FbEWHnqJm0TJMvrw==",
+      "dependencies": {
+        "any-signal": "^2.1.2",
+        "blob-to-it": "^1.0.1",
+        "browser-readablestream-to-it": "^1.0.1",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.7.3",
+        "ipfs-unixfs": "^6.0.3",
+        "ipfs-utils": "^8.1.4",
+        "it-all": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-peekable": "^1.0.2",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "multiformats": "^9.4.1",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^1.1.1",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/nft.storage/node_modules/ipfs-utils": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.6.tgz",
+      "integrity": "sha512-V/cwb6113DrDhrjDTWImA6+zmJbpdbUkxdxmEQO7it8ykV76bBmzU1ZXSM0QR0qxGy9VW8dkUlPAC2K10VgSmw==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "any-signal": "^2.1.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
+        "is-electron": "^2.2.0",
+        "iso-url": "^1.1.5",
+        "it-glob": "~0.0.11",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-abort-controller": "^1.0.3",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+        "react-native-fetch-api": "^2.0.0",
+        "stream-to-it": "^0.2.2"
+      }
+    },
+    "node_modules/nft.storage/node_modules/it-glob": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.14.tgz",
+      "integrity": "sha512-TKKzs9CglbsihSpcwJPXN5DBUssu4akRzPlp8QJRCoLrKoaOpyY2V1qDlxx+UMivn0i114YyTd4AawWl7eqIdw==",
+      "dependencies": {
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/nft.storage/node_modules/node-fetch": {
+      "name": "@achingbrain/node-fetch",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/nft.storage/node_modules/p-retry": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
@@ -3606,6 +3808,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nft.storage/node_modules/safari-14-idb-fix": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
+      "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA=="
     },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
@@ -4228,9 +4435,9 @@
       }
     },
     "node_modules/safari-14-idb-fix": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
-      "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
+      "integrity": "sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5611,6 +5818,21 @@
         "web-streams-polyfill": "3.0.3"
       }
     },
+    "@web-std/stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.0.tgz",
+      "integrity": "sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==",
+      "requires": {
+        "web-streams-polyfill": "^3.1.1"
+      },
+      "dependencies": {
+        "web-streams-polyfill": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+          "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
+        }
+      }
+    },
     "@web3-storage/multipart-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
@@ -5809,6 +6031,36 @@
       "integrity": "sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==",
       "requires": {
         "browser-readablestream-to-it": "^1.0.3"
+      }
+    },
+    "blockstore-core": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-1.0.2.tgz",
+      "integrity": "sha512-CYOaAvgVoJDqxbGG4YVyLMZ5mmS+Icwn7oHnayPko/FGpiinixI/CGMrErbDSaVSkjhuea9tpU23tt+Jx13n+g==",
+      "requires": {
+        "err-code": "^3.0.1",
+        "interface-blockstore": "^2.0.2",
+        "interface-store": "^2.0.1",
+        "it-drain": "^1.0.4",
+        "it-filter": "^1.0.2",
+        "it-take": "^1.0.1",
+        "multiformats": "^9.4.7"
+      },
+      "dependencies": {
+        "interface-blockstore": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.2.tgz",
+          "integrity": "sha512-2OonKanTF7xnlqe879EgYwv94e7jYO20dDMyqkDum7b9RnhdMkiLAOkeStlvxX1sZBLjcThyHzFTUYTK4ohKpg==",
+          "requires": {
+            "interface-store": "^2.0.1",
+            "multiformats": "^9.0.4"
+          }
+        },
+        "interface-store": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.1.tgz",
+          "integrity": "sha512-TfjYMdk4RlaGPA0VGk8fVPM+xhFbjiA2mTv1AqhiFh3N+ZEwoJnmDu/EBdKXzl80nyd0pvKui3RTC3zFgHMjTA=="
+        }
       }
     },
     "bn.js": {
@@ -6690,11 +6942,11 @@
       }
     },
     "idb-keyval": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.5.tgz",
-      "integrity": "sha512-J1utxYWQokYjy01LvDQ7WmiAtZCGUSkVi9EIBfUSyLOr/BesnMIxNGASTh9A1LzeISSjSqEPsfFdTss7EE7ofQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.0.3.tgz",
+      "integrity": "sha512-yh8V7CnE6EQMu9YDwQXhRxwZh4nv+8xm/HV4ZqK4IiYFJBWYGjJuykADJbSP+F/GDXUBwCSSNn/14IpGL81TuA==",
       "requires": {
-        "safari-14-idb-fix": "^1.0.6"
+        "safari-14-idb-fix": "^3.0.0"
       }
     },
     "ieee754": {
@@ -6747,19 +6999,20 @@
       }
     },
     "interface-datastore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-5.2.0.tgz",
-      "integrity": "sha512-nthO4C4BMJM2j9x/mT2KFa/g/sbcY8yf9j/kOBgli3u5mq9ZdPvQyDxi0OhKzr4JmoM81OYh5xcFjyebquqwvA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.0.3.tgz",
+      "integrity": "sha512-61eOyzh7zH1ks/56hPudW6pbqsOdoHSYMVjuqlIlZGjyg0svR6DHlCcaeSJfWW8t6dsPl1n7qKBdk8ZqPzXuLA==",
       "requires": {
-        "err-code": "^3.0.1",
-        "interface-store": "^1.0.2",
-        "ipfs-utils": "^8.1.2",
-        "it-all": "^1.0.2",
-        "it-drain": "^1.0.1",
-        "it-filter": "^1.0.2",
-        "it-take": "^1.0.1",
+        "interface-store": "^2.0.1",
         "nanoid": "^3.0.2",
         "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "interface-store": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.1.tgz",
+          "integrity": "sha512-TfjYMdk4RlaGPA0VGk8fVPM+xhFbjiA2mTv1AqhiFh3N+ZEwoJnmDu/EBdKXzl80nyd0pvKui3RTC3zFgHMjTA=="
+        }
       }
     },
     "interface-store": {
@@ -6783,21 +7036,22 @@
       "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
     "ipfs-car": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.9.tgz",
-      "integrity": "sha512-81jKWdkFj1XjP23Qu2ts5K4VOZsLySD4V4UH8fQeb1T6ETf5btdm24mhRRuY7hvM/Vq7AMtDc+bDXocO+WouJQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.6.0.tgz",
+      "integrity": "sha512-2qw6u0Or/5cVKUR4bBCF/fzXnePSSIyF7m1hNUfg6kOBR7LJOXq6hhlCgu+2zGWVye9idsW8jEoPM9wYJp67jA==",
       "requires": {
         "@ipld/car": "^3.1.4",
-        "@web-std/blob": "^2.1.1",
+        "@web-std/blob": "^3.0.1",
         "bl": "^5.0.0",
+        "blockstore-core": "^1.0.2",
         "browser-readablestream-to-it": "^1.0.2",
-        "idb-keyval": "^5.0.6",
-        "interface-blockstore": "^1.0.0",
-        "ipfs-core-types": "^0.7.0",
-        "ipfs-core-utils": "^0.10.1",
+        "idb-keyval": "^6.0.3",
+        "interface-blockstore": "^2.0.2",
+        "ipfs-core-types": "^0.8.3",
+        "ipfs-core-utils": "^0.12.1",
         "ipfs-unixfs-exporter": "^7.0.4",
         "ipfs-unixfs-importer": "^9.0.4",
-        "ipfs-utils": "^8.1.5",
+        "ipfs-utils": "^9.0.2",
         "it-all": "^1.0.5",
         "it-last": "^1.0.5",
         "it-pipe": "^1.1.0",
@@ -6807,36 +7061,65 @@
         "stream-to-it": "^0.2.3",
         "streaming-iterables": "^6.0.0",
         "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "@web-std/blob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.1.tgz",
+          "integrity": "sha512-opuhO8ZGGUj2jdFwfgMjWjVdKaHlQanGWXxj5wV2YQ1uGTuL/SADnsDitpMfRb+lSpmQyzpwZFfj4CNKQuwSKQ==",
+          "requires": {
+            "@web-std/stream": "1.0.0",
+            "web-encoding": "1.1.5"
+          }
+        },
+        "interface-blockstore": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.2.tgz",
+          "integrity": "sha512-2OonKanTF7xnlqe879EgYwv94e7jYO20dDMyqkDum7b9RnhdMkiLAOkeStlvxX1sZBLjcThyHzFTUYTK4ohKpg==",
+          "requires": {
+            "interface-store": "^2.0.1",
+            "multiformats": "^9.0.4"
+          }
+        },
+        "interface-store": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.1.tgz",
+          "integrity": "sha512-TfjYMdk4RlaGPA0VGk8fVPM+xhFbjiA2mTv1AqhiFh3N+ZEwoJnmDu/EBdKXzl80nyd0pvKui3RTC3zFgHMjTA=="
+        }
       }
     },
     "ipfs-core-types": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.7.3.tgz",
-      "integrity": "sha512-FkmOlqhEf3yG0K8Qt7We7kqA0xKjj8pe0dmNK593I3cgMP0MQS/xjMj1CXVdGeZc5Nn5CJ+TsuQydPbJ+7Y8eQ==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.8.4.tgz",
+      "integrity": "sha512-sbRZA1QX3xJ6ywTiVQZMOxhlhp4osAZX2SXx3azOLxAtxmGWDMkHYt722VV4nZ2GyJy8qyk5GHQIZ0uvQnpaTg==",
       "requires": {
-        "interface-datastore": "^5.2.0",
+        "interface-datastore": "^6.0.2",
         "multiaddr": "^10.0.0",
-        "multiformats": "^9.4.1"
+        "multiformats": "^9.4.13"
       }
     },
     "ipfs-core-utils": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.10.5.tgz",
-      "integrity": "sha512-WPRbMkbn/99pKMF3h8x1/c19+eTXVWOZu1+cmlc3NLR6gMlCd8KNpcq9OCAvs9G1JHx3w/FbEWHnqJm0TJMvrw==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.12.2.tgz",
+      "integrity": "sha512-RfxP3rPhXuqKIUmTAUhmee6fmaV3A7LMnjOUikRKpSyqESz/DR7aGK7tbttMxkZdkSEr0rFXlqbyb0vVwmn0wQ==",
       "requires": {
         "any-signal": "^2.1.2",
         "blob-to-it": "^1.0.1",
         "browser-readablestream-to-it": "^1.0.1",
+        "debug": "^4.1.1",
         "err-code": "^3.0.1",
-        "ipfs-core-types": "^0.7.3",
+        "ipfs-core-types": "^0.8.4",
         "ipfs-unixfs": "^6.0.3",
-        "ipfs-utils": "^8.1.4",
+        "ipfs-utils": "^9.0.2",
         "it-all": "^1.0.4",
         "it-map": "^1.0.4",
         "it-peekable": "^1.0.2",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
         "multiaddr": "^10.0.0",
         "multiaddr-to-uri": "^8.0.0",
-        "multiformats": "^9.4.1",
+        "multiformats": "^9.4.13",
+        "nanoid": "^3.1.23",
         "parse-duration": "^1.0.0",
         "timeout-abort-controller": "^1.1.1",
         "uint8arrays": "^3.0.0"
@@ -6891,9 +7174,9 @@
       }
     },
     "ipfs-utils": {
-      "version": "8.1.6",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.6.tgz",
-      "integrity": "sha512-V/cwb6113DrDhrjDTWImA6+zmJbpdbUkxdxmEQO7it8ykV76bBmzU1ZXSM0QR0qxGy9VW8dkUlPAC2K10VgSmw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.2.tgz",
+      "integrity": "sha512-o0DjVfd1kcr09fAYMkSnZ56ZkfoAzZhFWkizG3/tL7svukZpqyGyRxNlF58F+hsrn/oL8ouAP9x+4Hdf8XM+hg==",
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^2.1.0",
@@ -6902,7 +7185,7 @@
         "err-code": "^3.0.1",
         "is-electron": "^2.2.0",
         "iso-url": "^1.1.5",
-        "it-glob": "~0.0.11",
+        "it-glob": "^1.0.1",
         "it-to-stream": "^1.0.0",
         "merge-options": "^3.0.4",
         "nanoid": "^3.1.20",
@@ -6981,9 +7264,9 @@
       }
     },
     "is-electron": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
-      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
+      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -7151,9 +7434,9 @@
       "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
     },
     "it-glob": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.14.tgz",
-      "integrity": "sha512-TKKzs9CglbsihSpcwJPXN5DBUssu4akRzPlp8QJRCoLrKoaOpyY2V1qDlxx+UMivn0i114YyTd4AawWl7eqIdw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
       "requires": {
         "@types/minimatch": "^3.0.4",
         "minimatch": "^3.0.4"
@@ -7847,9 +8130,9 @@
       }
     },
     "multiformats": {
-      "version": "9.4.10",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.10.tgz",
-      "integrity": "sha512-BwWGvgqB/5J/cnWaOA0sXzJ+UGl+kyFAw3Sw1L6TN4oad34C9OpW+GCpYTYPDp4pUaXDC1EjvB3yv9Iodo1EhA=="
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.5.4.tgz",
+      "integrity": "sha512-MFT8e8BOLX7OZKfSBGm13FwYvJVI6MEcZ7hujUCpyJwvYyrC1anul50A0Ee74GdeJ77aYTO6YU1vO+oF8NqSIw=="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -7890,6 +8173,126 @@
         "streaming-iterables": "^6.0.0"
       },
       "dependencies": {
+        "idb-keyval": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.5.tgz",
+          "integrity": "sha512-J1utxYWQokYjy01LvDQ7WmiAtZCGUSkVi9EIBfUSyLOr/BesnMIxNGASTh9A1LzeISSjSqEPsfFdTss7EE7ofQ==",
+          "requires": {
+            "safari-14-idb-fix": "^1.0.6"
+          }
+        },
+        "interface-datastore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-5.2.0.tgz",
+          "integrity": "sha512-nthO4C4BMJM2j9x/mT2KFa/g/sbcY8yf9j/kOBgli3u5mq9ZdPvQyDxi0OhKzr4JmoM81OYh5xcFjyebquqwvA==",
+          "requires": {
+            "err-code": "^3.0.1",
+            "interface-store": "^1.0.2",
+            "ipfs-utils": "^8.1.2",
+            "it-all": "^1.0.2",
+            "it-drain": "^1.0.1",
+            "it-filter": "^1.0.2",
+            "it-take": "^1.0.1",
+            "nanoid": "^3.0.2",
+            "uint8arrays": "^3.0.0"
+          }
+        },
+        "ipfs-car": {
+          "version": "0.5.10",
+          "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.10.tgz",
+          "integrity": "sha512-+ItXLbKNH6S4JvNTl7sOtdecLsIVV/kenyUTWYbIMdwwTzoJwbkv+8qdTyA90E2R2xkZ3cXvNlpreujvLCP5Ng==",
+          "requires": {
+            "@ipld/car": "^3.1.4",
+            "@web-std/blob": "^2.1.1",
+            "bl": "^5.0.0",
+            "browser-readablestream-to-it": "^1.0.2",
+            "idb-keyval": "^5.0.6",
+            "interface-blockstore": "^1.0.0",
+            "ipfs-core-types": "^0.7.0",
+            "ipfs-core-utils": "^0.10.1",
+            "ipfs-unixfs-exporter": "^7.0.4",
+            "ipfs-unixfs-importer": "^9.0.4",
+            "ipfs-utils": "^8.1.5",
+            "it-all": "^1.0.5",
+            "it-last": "^1.0.5",
+            "it-pipe": "^1.1.0",
+            "meow": "^9.0.0",
+            "move-file": "^2.1.0",
+            "multiformats": "^9.3.0",
+            "stream-to-it": "^0.2.3",
+            "streaming-iterables": "^6.0.0",
+            "uint8arrays": "^3.0.0"
+          }
+        },
+        "ipfs-core-types": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.7.3.tgz",
+          "integrity": "sha512-FkmOlqhEf3yG0K8Qt7We7kqA0xKjj8pe0dmNK593I3cgMP0MQS/xjMj1CXVdGeZc5Nn5CJ+TsuQydPbJ+7Y8eQ==",
+          "requires": {
+            "interface-datastore": "^5.2.0",
+            "multiaddr": "^10.0.0",
+            "multiformats": "^9.4.1"
+          }
+        },
+        "ipfs-core-utils": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.10.5.tgz",
+          "integrity": "sha512-WPRbMkbn/99pKMF3h8x1/c19+eTXVWOZu1+cmlc3NLR6gMlCd8KNpcq9OCAvs9G1JHx3w/FbEWHnqJm0TJMvrw==",
+          "requires": {
+            "any-signal": "^2.1.2",
+            "blob-to-it": "^1.0.1",
+            "browser-readablestream-to-it": "^1.0.1",
+            "err-code": "^3.0.1",
+            "ipfs-core-types": "^0.7.3",
+            "ipfs-unixfs": "^6.0.3",
+            "ipfs-utils": "^8.1.4",
+            "it-all": "^1.0.4",
+            "it-map": "^1.0.4",
+            "it-peekable": "^1.0.2",
+            "multiaddr": "^10.0.0",
+            "multiaddr-to-uri": "^8.0.0",
+            "multiformats": "^9.4.1",
+            "parse-duration": "^1.0.0",
+            "timeout-abort-controller": "^1.1.1",
+            "uint8arrays": "^3.0.0"
+          }
+        },
+        "ipfs-utils": {
+          "version": "8.1.6",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.6.tgz",
+          "integrity": "sha512-V/cwb6113DrDhrjDTWImA6+zmJbpdbUkxdxmEQO7it8ykV76bBmzU1ZXSM0QR0qxGy9VW8dkUlPAC2K10VgSmw==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "any-signal": "^2.1.0",
+            "buffer": "^6.0.1",
+            "electron-fetch": "^1.7.2",
+            "err-code": "^3.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^1.1.5",
+            "it-glob": "~0.0.11",
+            "it-to-stream": "^1.0.0",
+            "merge-options": "^3.0.4",
+            "nanoid": "^3.1.20",
+            "native-abort-controller": "^1.0.3",
+            "native-fetch": "^3.0.0",
+            "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+            "react-native-fetch-api": "^2.0.0",
+            "stream-to-it": "^0.2.2"
+          }
+        },
+        "it-glob": {
+          "version": "0.0.14",
+          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.14.tgz",
+          "integrity": "sha512-TKKzs9CglbsihSpcwJPXN5DBUssu4akRzPlp8QJRCoLrKoaOpyY2V1qDlxx+UMivn0i114YyTd4AawWl7eqIdw==",
+          "requires": {
+            "@types/minimatch": "^3.0.4",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "node-fetch": {
+          "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
+        },
         "p-retry": {
           "version": "4.6.1",
           "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
@@ -7898,6 +8301,11 @@
             "@types/retry": "^0.12.0",
             "retry": "^0.13.1"
           }
+        },
+        "safari-14-idb-fix": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
+          "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA=="
         }
       }
     },
@@ -8353,9 +8761,9 @@
       }
     },
     "safari-14-idb-fix": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
-      "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-3.0.0.tgz",
+      "integrity": "sha512-eBNFLob4PMq8JA1dGyFn6G97q3/WzNtFK4RnzT1fnLq+9RyrGknzYiM/9B12MnKAxuj1IXr7UKYtTNtjyKMBog=="
     },
     "safe-buffer": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@web-std/file": "^1.1.4",
     "ajv": "^8.8.1",
     "files-from-path": "^0.2.1",
+    "ipfs-car": "^0.6.0",
     "multiformats": "^9.4.10",
     "nft.storage": "^4.0.0",
     "p-retry": "^5.0.0",

--- a/src/nft/bs-car-reader.js
+++ b/src/nft/bs-car-reader.js
@@ -1,0 +1,65 @@
+/**
+ * An implementation of the CAR reader interface that is backed by a blockstore.
+ *
+ * @typedef {import('multiformats').CID} CID
+ * @typedef {import('@ipld/car/api').CarReader} CarReader
+ * @implements {CarReader}
+ */
+export class BlockstoreCarReader {
+  /**
+   * @param {number} version
+   * @param {CID[]} roots
+   * @param {import('ipfs-car/blockstore').Blockstore} blockstore
+   */
+  constructor(version, roots, blockstore) {
+    /**
+     * @private
+     */
+    this._version = version
+    /**
+     * @private
+     */
+    this._roots = roots
+    /**
+     * @private
+     */
+    this._blockstore = blockstore
+  }
+
+  get version() {
+    return this._version
+  }
+
+  get blockstore() {
+    return this._blockstore
+  }
+
+  async getRoots() {
+    return this._roots
+  }
+
+  /**
+   * @param {CID} cid
+   */
+  has(cid) {
+    return this._blockstore.has(cid)
+  }
+
+  /**
+   * @param {CID} cid
+   */
+  async get(cid) {
+    const bytes = await this._blockstore.get(cid)
+    return { cid, bytes }
+  }
+
+  blocks() {
+    return this._blockstore.blocks()
+  }
+
+  async *cids() {
+    for await (const b of this.blocks()) {
+      yield b.cid
+    }
+  }
+}

--- a/src/nft/prepare.ts
+++ b/src/nft/prepare.ts
@@ -27,9 +27,9 @@ export interface PackagedNFT {
  * Encodes the given NFT metadata and asset files into CARs that can be uploaded to
  * NFT.Storage.
  *
- * First, the `imageFile` and any `additionalAssetFiles` are packed into a CAR,
- * and the root CID of this "asset CAR" is used to create IPFS URIs and gateway
- * URLs for each file in the NFT bundle.
+ * First, the `imageFile` and any `additionalAssetFiles` are packed into an IPFS
+ * directory object, and the root CID of the directory is used to create IPFS uris
+ * and gateway links to the assets.
  *
  * The input metadata is then modified:
  *
@@ -43,12 +43,13 @@ export interface PackagedNFT {
  *   with `cdn == false`, and the other will have an HTTP gateway URL, with
  *   `cdn == true`.
  *
- * This updated metadata is then serialized and packed into a second car.
- * Both CARs are returned in a {@link PackagedNFT} object, which also contains
- * the updated metadata object and links to the metadata.
+ * This updated metadata is then serialized to a JSON file, and additionally
+ * encoded into a [dag-cbor](https://github.com/ipld/ipld/blob/master/specs/codecs/dag-cbor/spec.md)
+ * block which links to the metadata JSON.
+ * The metadata and assets, plus the dag-cbor root block are encoded into a CAR for upload.
  *
  * Note that this function does NOT store anything with NFT.Storage. The links
- * in the returned {@link PackagedNFT} will not resolve until the CARs have been
+ * in the returned {@link PackagedNFT} will not resolve until the CAR has been
  * uploaded. Use {@link NFTStorageMetaplexor.storePreparedNFT} to upload.
  *
  * @param metadata a JS object containing (hopefully) valid Metaplex NFT metadata

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -26,8 +26,8 @@ export type ServiceContext = { auth: AuthContext; endpoint?: URL }
  * {@link NFTStorageMetaplexor.storeNFTFromFilesystem}.
  */
 export interface StoreNFTResult {
-  /** CID of the IPFS directory containing the metadata.json file for the NFT */
-  metadataRootCID: CIDString
+  /** CID of the IPFS DAG containing the metadata json file and all NFT assets. */
+  rootCID: CIDString
 
   /** CID of the IPFS directory containing all assets bundled with the NFT (including main image) */
   assetRootCID: CIDString
@@ -177,21 +177,12 @@ export class NFTStorageMetaplexor {
   ): Promise<StoreNFTResult> {
     this.init()
 
-    const metadataRootCID = await this.storeCar(
-      context,
-      nft.encodedMetadata.cid,
-      nft.encodedMetadata.car
-    )
-    const assetRootCID = await this.storeCar(
-      context,
-      nft.encodedAssets.cid,
-      nft.encodedAssets.car
-    )
+    const rootCID = await this.storeCar(context, nft.rootCID, nft.car)
     const { metadataGatewayURL, metadataURI } = nft
 
     return {
-      metadataRootCID,
-      assetRootCID,
+      rootCID,
+      assetRootCID: nft.assetRootCID.toString(),
       metadataGatewayURL,
       metadataURI,
       metadata: nft.metadata,

--- a/test/nft.spec.ts
+++ b/test/nft.spec.ts
@@ -13,9 +13,12 @@ describe('loadNFTFromFilesystem', () => {
       'token.json'
     )
     const nft = await loadNFTFromFilesystem(jsonPath)
-    const expectedURI =
-      'ipfs://bafybeiegbfxiiz26tqzrcl4xyhf42vxrseeouubiwhmmlgrb4t2rbdiruu/metadata.json'
-    expect(nft.metadataURI).to.equal(expectedURI)
+    expect(nft.metadataURI).to.contain('ipfs://')
+    expect(nft.metadataURI).to.contain(nft.rootCID.toString())
+    expect(nft.metadataURI).to.contain('metadata.json')
+    expect(nft.metadata.image).to.contain('https://')
+    expect(nft.metadata.image).to.contain(nft.assetRootCID.toString())
+    expect(nft.metadata.image).to.contain('token.png')
   })
 
   it('finds image file if json "image" field contains valid file path', async () => {
@@ -27,9 +30,12 @@ describe('loadNFTFromFilesystem', () => {
       'image-path-in-image-field.json'
     )
     const nft = await loadNFTFromFilesystem(jsonPath)
-    const expectedURI =
-      'ipfs://bafybeiegbfxiiz26tqzrcl4xyhf42vxrseeouubiwhmmlgrb4t2rbdiruu/metadata.json'
-    expect(nft.metadataURI).to.equal(expectedURI)
+    expect(nft.metadataURI).to.contain('ipfs://')
+    expect(nft.metadataURI).to.contain(nft.rootCID.toString())
+    expect(nft.metadataURI).to.contain('metadata.json')
+    expect(nft.metadata.image).to.contain('https://')
+    expect(nft.metadata.image).to.contain(nft.assetRootCID.toString())
+    expect(nft.metadata.image).to.contain('token.png')
   })
 
   it('works with a manually specified imageFilePath', async () => {
@@ -48,8 +54,11 @@ describe('loadNFTFromFilesystem', () => {
       'token.png'
     )
     const nft = await loadNFTFromFilesystem(jsonPath, imagePath)
-    const expectedURI =
-      'ipfs://bafybeiegbfxiiz26tqzrcl4xyhf42vxrseeouubiwhmmlgrb4t2rbdiruu/metadata.json'
-    expect(nft.metadataURI).to.equal(expectedURI)
+    expect(nft.metadataURI).to.contain('ipfs://')
+    expect(nft.metadataURI).to.contain(nft.rootCID.toString())
+    expect(nft.metadataURI).to.contain('metadata.json')
+    expect(nft.metadata.image).to.contain('https://')
+    expect(nft.metadata.image).to.contain(nft.assetRootCID.toString())
+    expect(nft.metadata.image).to.contain('token.png')
   })
 })

--- a/test/upload.spec.ts
+++ b/test/upload.spec.ts
@@ -85,7 +85,7 @@ describe('NFTStorageMetaplexor', () => {
       )
       const result = await client.storeNFTFromFilesystem(metadataPath)
       expect(result.assetRootCID).to.not.be.empty
-      expect(result.metadataRootCID).to.not.be.empty
+      expect(result.rootCID).to.not.be.empty
       expect(result.metadata['image']).to.eq(
         `https://dweb.link/ipfs/${result.assetRootCID}/token.png`
       )


### PR DESCRIPTION
This changes the `prepareMetaplexNFT` function to pack everything into a single CAR, instead of splitting things into an "asset CAR" and "metadata CAR".

The rationale is that using two CARs will require two signature authorizations per-NFT when signing in a browser, which is more friction than necessary. It's also just nice to have a 1:1 NFT -> CAR mapping and seems like it will make things easier to keep track of over time (e.g. when correlating uploads with minted NFTs).

I also added a dag-cbor representation of the metadata as the root block, with a link to the `metadata.json` inside, similar to the IPNFT created by the client's `store` method. I'm not sure if it matters, but I set the `type` field to `nft/metaplex` instead of `nft`, just to make it easier to distinguish from things created using the `store` method.
