### PR TITLE
feat: add required "mintingAgent" tag

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -71,7 +71,7 @@ Indicates the blockchain that will be used for minting. Currently the only valid
 
 Indicates which [Solana cluster](https://docs.solana.com/clusters) will be used for minting. Must be provided when `chain == "solana"`. Acceptable values are: `"mainnet-beta"`, `"devnet"`, `"testnet"`.
 
-**Note:** an earlier draft of this spec & library used the key `solana-cluster` for this tag. This was changed to "camel case" for consistency and to play nice with JavaScript conventions. The original key will be supported on the backend for a short time, but support will be removed in early 2022.
+**Note:** an earlier draft of this spec & library used the key `solana-cluster` for this tag. This was changed to "camel case" for consistency and to play nice with JavaScript conventions.
 
 ##### `mintingAgent`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 Author: Yusef Napora <yusef@protocol.ai>
 
-Last revision: 2021-12-01
+Last revision: 2021-12-10
 
 This document describes the public-key based authentication scheme used to make [NFT.Storage](https://nft.storage) accessible to all Metaplex users free of charge.
 
@@ -40,8 +40,10 @@ An example token payload looks like this:
     "put": {
       "rootCID": "bafkreifeqjorwymdmh77ars6tbrtno74gntsdcvqvcycucidebiri2e7qy",
       "tags": {
+        "mintingAgent": "my-awesome-tool",
+        "agentVersion": "0.1.0",
         "chain": "solana",
-        "solana-cluster": "devnet"
+        "solanaCluster": "devnet"
       }
     }
   }
@@ -59,7 +61,40 @@ There is currently only one supported request type, `put`, which uploads a CAR f
 A `put` request description must contain a `rootCID` field whose value is the root CID of a Content Archive included in the request body.
 The CID should be encoded as a CIDv1 string.
 
-The `put` object also contains a `tags` key/value map that may contain arbitrary metadata tags. Currently this is used to identify the target blockchain (always `solana`) and the cluster that the user intends to mint on (e.g. `devnet` or `mainnet-beta`). Unrecognized tags will be discarded by the backend, and tags should not be used to store arbitrary metadata. Future revisions to this spec may introduce additional tags.
+The `put` object also contains a `tags` key/value map that may contain arbitrary metadata tags. Currently accepted tags are listed below:
+
+##### `chain`
+
+Indicates the blockchain that will be used for minting. Currently the only valid value is `"solana"`.
+
+##### `solanaCluster`
+
+Indicates which [Solana cluster](https://docs.solana.com/clusters) will be used for minting. Must be provided when `chain == "solana"`. Acceptable values are: `"mainnet-beta"`, `"devnet"`, `"testnet"`.
+
+**Note:** an earlier draft of this spec & library used the key `solana-cluster` for this tag. This was changed to "camel case" for consistency and to play nice with JavaScript conventions. The original key will be supported on the backend for a short time, but support will be removed in early 2022.
+
+##### `mintingAgent`
+
+The `tags` map MUST include a `mintingAgent` tag, whose value should identify the tool or platform used to prepare the upload.
+
+Projects using this library are free to choose their own value for this tag, however you should avoid changing the name over time, unless the project itself changes names (for example, due to a community fork or re-branding).
+
+For personal projects or individuals creating tools that are not affiliated with a public platform, please set the value to a URL for your code repository. If your code is not yet public, please create a repository containing a description of the project and links to its public-facing interface.
+
+Examples of suitable values:
+
+- `"metaplex/candy-machine-cli"`
+- `"metaplex/js-sdk"`
+- `"magiceden/mint-authority"`
+- `"https://github.com/samuelvanderwaal/metaboss"`
+
+##### `agentVersion`
+
+The tags map may optionally include an `agentVersion` tag that identifies a specific version of the tool or platform, using whatever convention is used by the project (e.g. semver, etc.)
+
+##### Unrecognized tags
+
+Unrecognized tags will be discarded by the backend, and tags should not be used to store arbitrary metadata. Future revisions to this spec may introduce additional tags.
 
 ### Signing the token
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import {
 } from './auth'
 import { NFTStorageMetaplexor } from './upload'
 import { getFilesFromPath } from 'files-from-path'
+import { version as projectVersion } from '../package.json'
 
 interface IArgs {
   keyfile: string
@@ -17,6 +18,7 @@ interface IArgs {
   files?: string[]
 }
 
+const MINTING_AGENT = 'metaplex-auth/cli'
 const CLUSTER_VALUES = ['mainnet-beta', 'devnet']
 const DEFAULT_CLUSTER = 'devnet'
 
@@ -101,10 +103,14 @@ async function loadKey(keyfilePath: string): Promise<Uint8Array> {
 
 async function makeAuthContext(
   keyfilePath: string,
-  cluster: SolanaCluster
+  solanaCluster: SolanaCluster
 ): Promise<AuthContext> {
   const secretKey = await loadKey(keyfilePath)
-  return MetaplexAuthWithSecretKey(secretKey, cluster)
+  return MetaplexAuthWithSecretKey(secretKey, {
+    mintingAgent: MINTING_AGENT,
+    agentVersion: projectVersion,
+    solanaCluster,
+  })
 }
 
 main()

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -79,16 +79,27 @@ export class NFTStorageMetaplexor {
    *
    * @param key - an Ed25519 private key
    * @param opts
+   * @param opts.mintingAgent - the "user agent" or tool used to prepare the upload. See {@link TagMintingAgent} for details.
+   * @param opts.agentVersion - an optional version of the `mintingAgent`. See {@link TagMintingAgentVersion} for details.
    * @param opts.solanaCluster - the Solana cluster that the uploaded NFTs are to be minted on. defaults to 'devnet' if not provided.
    * @param opts.endpoint - the URL of the NFT.Storage API. defaults to 'https://api.nft.storage' if not provided.
    * @returns
    */
   static withSecretKey(
     key: Uint8Array,
-    opts: { solanaCluster?: SolanaCluster; endpoint?: URL } = {}
+    opts: {
+      mintingAgent: string
+      agentVersion?: string
+      solanaCluster?: SolanaCluster
+      endpoint?: URL
+    }
   ) {
-    const { solanaCluster, endpoint } = opts
-    const auth = MetaplexAuthWithSecretKey(key, solanaCluster)
+    const { solanaCluster, mintingAgent, agentVersion, endpoint } = opts
+    const auth = MetaplexAuthWithSecretKey(key, {
+      solanaCluster,
+      mintingAgent,
+      agentVersion,
+    })
     return new NFTStorageMetaplexor({ auth, endpoint })
   }
 
@@ -102,6 +113,8 @@ export class NFTStorageMetaplexor {
    * @param signMessage - a function that asynchronously returns a signature of an input message
    * @param publicKey - the public key that can validate signatures produced by the signer
    * @param opts
+   * @param opts.mintingAgent - the "user agent" or tool used to prepare the upload. See {@link TagMintingAgent} for details.
+   * @param opts.agentVersion - an optional version of the `mintingAgent`. See {@link TagMintingAgentVersion} for details.
    * @param opts.solanaCluster - the Solana cluster that the uploaded NFTs are to be minted on. defaults to 'devnet' if not provided.
    * @param opts.endpoint - the URL of the NFT.Storage API. defaults to 'https://api.nft.storage' if not provided.
    * @returns
@@ -109,10 +122,19 @@ export class NFTStorageMetaplexor {
   static withSigner(
     signMessage: Signer,
     publicKey: Uint8Array,
-    opts: { solanaCluster?: SolanaCluster; endpoint?: URL } = {}
+    opts: {
+      mintingAgent: string
+      agentVersion?: string
+      solanaCluster?: SolanaCluster
+      endpoint?: URL
+    }
   ) {
-    const { solanaCluster, endpoint } = opts
-    const auth = MetaplexAuthWithSigner(signMessage, publicKey, solanaCluster)
+    const { solanaCluster, mintingAgent, agentVersion, endpoint } = opts
+    const auth = MetaplexAuthWithSigner(signMessage, publicKey, {
+      solanaCluster,
+      mintingAgent,
+      agentVersion,
+    })
     return new NFTStorageMetaplexor({ auth, endpoint })
   }
 

--- a/test/upload.spec.ts
+++ b/test/upload.spec.ts
@@ -24,7 +24,9 @@ describe('NFTStorageMetaplexor', () => {
 
   describe('withSecretKey', () => {
     it('creates an instance with an AuthContext backed by the given key', async () => {
-      const client = NFTStorageMetaplexor.withSecretKey(secretKey)
+      const client = NFTStorageMetaplexor.withSecretKey(secretKey, {
+        mintingAgent: 'unit-tests',
+      })
       expect(client.auth.publicKey).to.deep.eq(publicKey)
 
       const { msg, sig } = await signRandomMessage(client.auth)
@@ -38,7 +40,9 @@ describe('NFTStorageMetaplexor', () => {
       const signMessage = async (msg: Uint8Array) =>
         nacl.sign.detached(msg, secretKey)
 
-      const client = NFTStorageMetaplexor.withSigner(signMessage, publicKey)
+      const client = NFTStorageMetaplexor.withSigner(signMessage, publicKey, {
+        mintingAgent: 'unit-tests',
+      })
       expect(client.auth.publicKey).to.deep.eq(publicKey)
 
       const { msg, sig } = await signRandomMessage(client.auth)
@@ -49,7 +53,10 @@ describe('NFTStorageMetaplexor', () => {
 
   describe('storeDirectory', () => {
     it('posts a CAR to /metaplex/upload', async () => {
-      const client = NFTStorageMetaplexor.withSecretKey(secretKey, { endpoint })
+      const client = NFTStorageMetaplexor.withSecretKey(secretKey, {
+        endpoint,
+        mintingAgent: 'unit-tests',
+      })
       const dir = path.join(__dirname, 'fixtures', 'nfts', '01-simple-example')
       const files = await getFilesFromPath(dir)
       // @ts-ignore getFilesFromPath returns a different File object type. TODO: fix type def on storeDirectory to be more permissive
@@ -60,7 +67,10 @@ describe('NFTStorageMetaplexor', () => {
 
   describe('storeCar', () => {
     it('posts a CAR to /metaplex/upload', async () => {
-      const client = NFTStorageMetaplexor.withSecretKey(secretKey, { endpoint })
+      const client = NFTStorageMetaplexor.withSecretKey(secretKey, {
+        endpoint,
+        mintingAgent: 'unit-tests',
+      })
       const dir = path.join(__dirname, 'fixtures', 'cars')
       const filenames = await fs.readdir(dir)
       for (const f of filenames) {
@@ -75,7 +85,10 @@ describe('NFTStorageMetaplexor', () => {
 
   describe('storeNFTFromFilesystem', () => {
     it('loads an NFT from disk and posts two CARs to /metaplex/upload', async () => {
-      const client = NFTStorageMetaplexor.withSecretKey(secretKey, { endpoint })
+      const client = NFTStorageMetaplexor.withSecretKey(secretKey, {
+        endpoint,
+        mintingAgent: 'unit-tests',
+      })
       const metadataPath = path.join(
         __dirname,
         'fixtures',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,5 +64,5 @@
     "resolveJsonModule": true /* allow importing json files */
   },
   "include": ["src", "test"],
-  "files": ["test/fixtures/metadata.json"]
+  "files": ["package.json", "test/fixtures/metadata.json"]
 }


### PR DESCRIPTION
This adds a required `mintingAgent` tag to the auth payload, which should be used to identify the tool or platform using this library to prepare and upload NFTs on behalf of the user. It also adds an optional `agentVersion` tag, which seems like it might come in handy but might not be useful for all projects.

Also updates the `MetaplexAuthWithSecretKey` and `MetaplexAuthWithSigner` functions to accept an options object instead of just the solana cluster name, and requires that `mintingAgent` is present. Likewise, the `NFTStorageMetaplexor` factory methods now accept the new tags and will throw if not given a `mintingAgent`.

Finally, as long as we're adding new constraints to the tags, I snuck in a breaking name change for the Solana cluster tag, from `solana-cluster` to `solanaCluster`. No clue why I went with kebab-case originally, but it's been annoying me ever since, and I'd rather change it now than after people start heavily using the lib 😄.

Will need a small API change to grab the new tags out of the payload and use the new `solanaCluster` tag name.
