### PR TITLE
feat: make properties.creators optional to support token standard v1.1.0

### DIFF
--- a/src/metadata/schema.ts
+++ b/src/metadata/schema.ts
@@ -43,7 +43,7 @@ export interface MetaplexMetadata {
   properties: {
     category?: string
     files: Array<FileDescription>
-    creators: CreatorInfo[]
+    creators?: CreatorInfo[]
   }
 }
 
@@ -115,10 +115,11 @@ export const metadataSchema: JSONSchemaType<MetaplexMetadata> = {
         creators: {
           type: 'array',
           items: creatorSchema,
+          nullable: true,
         },
       },
       additionalProperties: true,
-      required: ['files', 'creators'],
+      required: ['files'],
     },
     collection: {
       type: 'object',


### PR DESCRIPTION
closes #30 