### PR TITLE
feat: add storeBlob methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nftstorage/metaplex-auth",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nftstorage/metaplex-auth",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@dashkite/tweetnacl": "^1.0.3",
@@ -16,7 +16,7 @@
         "ajv": "^8.8.1",
         "files-from-path": "^0.2.1",
         "multiformats": "^9.6.2",
-        "nft.storage": "^5.2.2",
+        "nft.storage": "^5.2.5",
         "p-retry": "^5.0.0",
         "path-browserify": "^1.0.1",
         "streaming-iterables": "^6.0.0",
@@ -256,9 +256,9 @@
       }
     },
     "node_modules/@multiformats/murmur3": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.0.8.tgz",
-      "integrity": "sha512-neeqwdZ7CmvNQEr+M7mFIC71Wy+SI2dxoOGm5eFpA0Jw7bMaoOXsOhY21JeFVScPlRi1t5+6UF3/nzfdMvOGlw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.1.tgz",
+      "integrity": "sha512-TPIBMPX4DX7T4291bPUAn/AMW6H6mnYoI4Bza1DeX1I59dpTWBbOgxaqc+139Ph+NEgb/PNd3sFS8VFoOXzNlw==",
       "dependencies": {
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
@@ -2364,18 +2364,18 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/interface-blockstore": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.2.tgz",
-      "integrity": "sha512-2OonKanTF7xnlqe879EgYwv94e7jYO20dDMyqkDum7b9RnhdMkiLAOkeStlvxX1sZBLjcThyHzFTUYTK4ohKpg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.3.tgz",
+      "integrity": "sha512-OwVUnlNcx7H5HloK0Myv6c/C1q9cNG11HX6afdeU6q6kbuNj8jKCwVnmJHhC94LZaJ+9hvVOk4IUstb3Esg81w==",
       "dependencies": {
-        "interface-store": "^2.0.1",
+        "interface-store": "^2.0.2",
         "multiformats": "^9.0.4"
       }
     },
     "node_modules/interface-datastore": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.0.3.tgz",
-      "integrity": "sha512-61eOyzh7zH1ks/56hPudW6pbqsOdoHSYMVjuqlIlZGjyg0svR6DHlCcaeSJfWW8t6dsPl1n7qKBdk8ZqPzXuLA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.0.tgz",
+      "integrity": "sha512-oNHdsrWBsI/kDwUtEgt+aaZtQFKtQYN0TGZzc3SGiIA6m+plZ6malhmsygtbmDpfpIsNNC7ce9Gyaj+Tki+gVw==",
       "dependencies": {
         "interface-store": "^2.0.1",
         "nanoid": "^3.0.2",
@@ -2383,9 +2383,9 @@
       }
     },
     "node_modules/interface-store": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.1.tgz",
-      "integrity": "sha512-TfjYMdk4RlaGPA0VGk8fVPM+xhFbjiA2mTv1AqhiFh3N+ZEwoJnmDu/EBdKXzl80nyd0pvKui3RTC3zFgHMjTA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -2409,11 +2409,11 @@
       }
     },
     "node_modules/ipfs-car": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.6.1.tgz",
-      "integrity": "sha512-wB2e009VkWz3OXEFYiT1Vpvn3IJlyGcWJky8NgcgpeY/b5dgNFR8bHlbWhJJQJtys8D16n9TFuGgrROspe1gpw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.6.2.tgz",
+      "integrity": "sha512-tliuakkKKtCa4TTnFT3zJKjq/aD8EGKX8Y0ybCyrAW0fo/n2koZpxiLjBvtTs47Rqyji6ggXo+atPbJJ60hJmg==",
       "dependencies": {
-        "@ipld/car": "^3.1.4",
+        "@ipld/car": "^3.2.3",
         "@web-std/blob": "^3.0.1",
         "bl": "^5.0.0",
         "blockstore-core": "^1.0.2",
@@ -2430,7 +2430,7 @@
         "it-pipe": "^1.1.0",
         "meow": "^9.0.0",
         "move-file": "^2.1.0",
-        "multiformats": "^9.3.0",
+        "multiformats": "^9.6.3",
         "stream-to-it": "^0.2.3",
         "streaming-iterables": "^6.0.0",
         "uint8arrays": "^3.0.0"
@@ -3780,9 +3780,9 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.2.tgz",
-      "integrity": "sha512-1dKng7RkBelbEZQQD2zvdzYKgUmtggpWl+GXQBYhnEGGkV6VIYfWgV3VSeyhcUFFEelI5q4D0etCJZ7fbuiamQ=="
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.3.tgz",
+      "integrity": "sha512-yfXKI66fL0nFzt0nJl26i4wV1qAqbAEIBvfFbkbsne9GrLz6IHvHUoRyxUtlJcdP181ssOgjama6E/VSk4pbrA=="
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -3820,19 +3820,19 @@
       }
     },
     "node_modules/nft.storage": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/nft.storage/-/nft.storage-5.2.2.tgz",
-      "integrity": "sha512-HwJVbkUcknNjJxDlOld4lU1GxBuxe2kaNTmzzixaee+Sp+B4bmo03vElamDTuloeTid91GNKz/MWuNByXlxMDQ==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/nft.storage/-/nft.storage-5.2.5.tgz",
+      "integrity": "sha512-ITP9ETleKIZvSRsjpHi6JFFE/YVcp9jwwyi+Q1GtdNmFc5Xyu1g7it+yrk7m5+iSEMcOjSJGPQrktnUTe0qtAg==",
       "dependencies": {
-        "@ipld/car": "^3.1.20",
+        "@ipld/car": "^3.2.3",
         "@ipld/dag-cbor": "^6.0.13",
         "@web-std/blob": "^3.0.1",
-        "@web-std/fetch": "^3.0.0",
+        "@web-std/fetch": "^3.0.3",
         "@web-std/file": "^3.0.0",
         "@web-std/form-data": "^3.0.0",
         "carbites": "^1.0.6",
-        "ipfs-car": "^0.6.0",
-        "multiformats": "^9.4.10",
+        "ipfs-car": "^0.6.2",
+        "multiformats": "^9.6.3",
         "p-retry": "^4.6.1",
         "streaming-iterables": "^6.0.0"
       }
@@ -3856,9 +3856,9 @@
       }
     },
     "node_modules/nft.storage/node_modules/@web-std/fetch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-3.0.2.tgz",
-      "integrity": "sha512-kZO3KuZ1xvdxqTUFAAuNU+eK9ugZtmkP4yYZUzhx8+1vvwvv1t6WnG6khSMyzk9PpZaq+aepx45nC0YskiT6ZQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-3.0.3.tgz",
+      "integrity": "sha512-PtaKr6qvw2AmKChugzhQWuTa12dpbogHRBxwcleAZ35UhWucnfD4N+g3f7qYK2OeioSWTK3yMf6n/kOOfqxHaQ==",
       "dependencies": {
         "@web-std/blob": "^3.0.3",
         "@web-std/form-data": "^3.0.2",
@@ -5722,9 +5722,9 @@
       }
     },
     "@multiformats/murmur3": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.0.8.tgz",
-      "integrity": "sha512-neeqwdZ7CmvNQEr+M7mFIC71Wy+SI2dxoOGm5eFpA0Jw7bMaoOXsOhY21JeFVScPlRi1t5+6UF3/nzfdMvOGlw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.1.tgz",
+      "integrity": "sha512-TPIBMPX4DX7T4291bPUAn/AMW6H6mnYoI4Bza1DeX1I59dpTWBbOgxaqc+139Ph+NEgb/PNd3sFS8VFoOXzNlw==",
       "requires": {
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
@@ -7308,18 +7308,18 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "interface-blockstore": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.2.tgz",
-      "integrity": "sha512-2OonKanTF7xnlqe879EgYwv94e7jYO20dDMyqkDum7b9RnhdMkiLAOkeStlvxX1sZBLjcThyHzFTUYTK4ohKpg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.3.tgz",
+      "integrity": "sha512-OwVUnlNcx7H5HloK0Myv6c/C1q9cNG11HX6afdeU6q6kbuNj8jKCwVnmJHhC94LZaJ+9hvVOk4IUstb3Esg81w==",
       "requires": {
-        "interface-store": "^2.0.1",
+        "interface-store": "^2.0.2",
         "multiformats": "^9.0.4"
       }
     },
     "interface-datastore": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.0.3.tgz",
-      "integrity": "sha512-61eOyzh7zH1ks/56hPudW6pbqsOdoHSYMVjuqlIlZGjyg0svR6DHlCcaeSJfWW8t6dsPl1n7qKBdk8ZqPzXuLA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.0.tgz",
+      "integrity": "sha512-oNHdsrWBsI/kDwUtEgt+aaZtQFKtQYN0TGZzc3SGiIA6m+plZ6malhmsygtbmDpfpIsNNC7ce9Gyaj+Tki+gVw==",
       "requires": {
         "interface-store": "^2.0.1",
         "nanoid": "^3.0.2",
@@ -7327,9 +7327,9 @@
       }
     },
     "interface-store": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.1.tgz",
-      "integrity": "sha512-TfjYMdk4RlaGPA0VGk8fVPM+xhFbjiA2mTv1AqhiFh3N+ZEwoJnmDu/EBdKXzl80nyd0pvKui3RTC3zFgHMjTA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -7347,11 +7347,11 @@
       "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
     "ipfs-car": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.6.1.tgz",
-      "integrity": "sha512-wB2e009VkWz3OXEFYiT1Vpvn3IJlyGcWJky8NgcgpeY/b5dgNFR8bHlbWhJJQJtys8D16n9TFuGgrROspe1gpw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.6.2.tgz",
+      "integrity": "sha512-tliuakkKKtCa4TTnFT3zJKjq/aD8EGKX8Y0ybCyrAW0fo/n2koZpxiLjBvtTs47Rqyji6ggXo+atPbJJ60hJmg==",
       "requires": {
-        "@ipld/car": "^3.1.4",
+        "@ipld/car": "^3.2.3",
         "@web-std/blob": "^3.0.1",
         "bl": "^5.0.0",
         "blockstore-core": "^1.0.2",
@@ -7368,7 +7368,7 @@
         "it-pipe": "^1.1.0",
         "meow": "^9.0.0",
         "move-file": "^2.1.0",
-        "multiformats": "^9.3.0",
+        "multiformats": "^9.6.3",
         "stream-to-it": "^0.2.3",
         "streaming-iterables": "^6.0.0",
         "uint8arrays": "^3.0.0"
@@ -8400,9 +8400,9 @@
       }
     },
     "multiformats": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.2.tgz",
-      "integrity": "sha512-1dKng7RkBelbEZQQD2zvdzYKgUmtggpWl+GXQBYhnEGGkV6VIYfWgV3VSeyhcUFFEelI5q4D0etCJZ7fbuiamQ=="
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.3.tgz",
+      "integrity": "sha512-yfXKI66fL0nFzt0nJl26i4wV1qAqbAEIBvfFbkbsne9GrLz6IHvHUoRyxUtlJcdP181ssOgjama6E/VSk4pbrA=="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -8427,19 +8427,19 @@
       "requires": {}
     },
     "nft.storage": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/nft.storage/-/nft.storage-5.2.2.tgz",
-      "integrity": "sha512-HwJVbkUcknNjJxDlOld4lU1GxBuxe2kaNTmzzixaee+Sp+B4bmo03vElamDTuloeTid91GNKz/MWuNByXlxMDQ==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/nft.storage/-/nft.storage-5.2.5.tgz",
+      "integrity": "sha512-ITP9ETleKIZvSRsjpHi6JFFE/YVcp9jwwyi+Q1GtdNmFc5Xyu1g7it+yrk7m5+iSEMcOjSJGPQrktnUTe0qtAg==",
       "requires": {
-        "@ipld/car": "^3.1.20",
+        "@ipld/car": "^3.2.3",
         "@ipld/dag-cbor": "^6.0.13",
         "@web-std/blob": "^3.0.1",
-        "@web-std/fetch": "^3.0.0",
+        "@web-std/fetch": "^3.0.3",
         "@web-std/file": "^3.0.0",
         "@web-std/form-data": "^3.0.0",
         "carbites": "^1.0.6",
-        "ipfs-car": "^0.6.0",
-        "multiformats": "^9.4.10",
+        "ipfs-car": "^0.6.2",
+        "multiformats": "^9.6.3",
         "p-retry": "^4.6.1",
         "streaming-iterables": "^6.0.0"
       },
@@ -8463,9 +8463,9 @@
           }
         },
         "@web-std/fetch": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-3.0.2.tgz",
-          "integrity": "sha512-kZO3KuZ1xvdxqTUFAAuNU+eK9ugZtmkP4yYZUzhx8+1vvwvv1t6WnG6khSMyzk9PpZaq+aepx45nC0YskiT6ZQ==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-3.0.3.tgz",
+          "integrity": "sha512-PtaKr6qvw2AmKChugzhQWuTa12dpbogHRBxwcleAZ35UhWucnfD4N+g3f7qYK2OeioSWTK3yMf6n/kOOfqxHaQ==",
           "requires": {
             "@web-std/blob": "^3.0.3",
             "@web-std/form-data": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ajv": "^8.8.1",
     "files-from-path": "^0.2.1",
     "multiformats": "^9.6.2",
-    "nft.storage": "^5.2.2",
+    "nft.storage": "^5.2.5",
     "p-retry": "^5.0.0",
     "path-browserify": "^1.0.1",
     "streaming-iterables": "^6.0.0",

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -139,6 +139,23 @@ export class NFTStorageMetaplexor {
   }
 
   /**
+   * Stores a single Blob (or File) with NFT.Storage, without wrapping in a directory listing.
+   * If a File is provided, any filenames will be ignored and will not be preserved on IPFS.
+   *
+   * @param context information required to authenticate uploads
+   * @param blob a Blob or File object to store
+   * @returns CID string for the stored content
+   */
+  static async storeBlob(
+    context: ServiceContext,
+    blob: Blob
+  ): Promise<CIDString> {
+    this.init()
+    const { cid, car } = await NFTStorage.encodeBlob(blob)
+    return this.storeCar(context, cid, car)
+  }
+
+  /**
    * Stores one or more files with NFT.Storage, bundling them into an IPFS directory.
    *
    * If the `files` contain directory paths in their `name`s, they MUST all share the same
@@ -245,6 +262,18 @@ export class NFTStorageMetaplexor {
   }
 
   // -- instance methods are just "sugar" around the static methods, using `this` as the ServiceContext parameter
+
+  /**
+   * Stores a single Blob (or File) with NFT.Storage, without wrapping in a directory listing.
+   * If a File is provided, any filenames will be ignored and will not be preserved on IPFS.
+   *
+   * @param blob a Blob or File object to store
+   * @returns CID string for the stored content
+   */
+  async storeBlob(blob: Blob): Promise<CIDString> {
+    const { cid, car } = await NFTStorage.encodeBlob(blob)
+    return NFTStorageMetaplexor.storeCar(this, cid, car)
+  }
 
   /**
    * Stores a Content Archive (CAR) containing content addressed data.

--- a/test/upload.spec.ts
+++ b/test/upload.spec.ts
@@ -8,6 +8,7 @@ import { CID } from 'multiformats'
 import { CarIndexedReader } from '@ipld/car'
 import { getFilesFromPath } from 'files-from-path'
 import { NFTStorageMetaplexor } from '../src/upload.js'
+import { Blob } from '../src/platform.js'
 import type { AuthContext } from '../src/auth.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -51,6 +52,18 @@ describe('NFTStorageMetaplexor', () => {
       const { msg, sig } = await signRandomMessage(client.auth)
       const valid = nacl.sign.detached.verify(msg, sig, publicKey)
       expect(valid, 'AuthContext created invalid signature for public key')
+    })
+  })
+
+  describe('storeBlob', () => {
+    it('posts a CAR to /metaplex/upload', async () => {
+      const client = NFTStorageMetaplexor.withSecretKey(secretKey, {
+        endpoint,
+        mintingAgent: 'unit-tests',
+      })
+      const blob = new Blob(['hello world'])
+      const cid = await client.storeBlob(blob)
+      expect(cid).to.not.be.empty
     })
   })
 


### PR DESCRIPTION
This adds a `storeBlob` method to the main `NFTStorageMetaplexor` class.

Motivation:

I'm working on https://github.com/nftstorage/nft.storage/issues/1275, to re-open a new PR to add this lib to the metaplex candy-machine cli and replace the direct HTTP-API uploader they merged in a little bit ago.

To make the PR easy to follow, I'm planning to just port their uploader function to use either the standard nft.storage client or the `NFTStorageMetaplexor`, depending on whether you have an NFT.Storage api key. Their current uploader basically uses the HTTP API equivalent of `storeBlob`, so the simplest thing is to just use that.

Adding `storeBlob` here means `NFTStorageMetaplexor` will overlap enough with the `NFTStorage` api that I'll just need one conditional to figure out which one to construct, and I can just call `storeBlob` on either one.